### PR TITLE
Include return types from docblock definitions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,11 @@
         "spatie/laravel-package-tools": "^1.4.3"
     },
     "require-dev": {
+        "barryvdh/laravel-ide-helper": "^2.10",
         "brianium/paratest": "^6.2",
         "nunomaduro/collision": "^5.3",
         "orchestra/testbench": "^6.15",
+        "phpdocumentor/type-resolver": "^1.4",
         "phpunit/phpunit": "^9.3",
         "spatie/laravel-ray": "^1.9",
         "vimeo/psalm": "^4.4"


### PR DESCRIPTION
Currently, it appears as if only the return type declaration for an action has docs generated for it.

This PR updates the return type handling to include the definitions included in the docblock provided for an action (if provided).

This provides the ability to provide type hints for actions that aren't yet supported by PHP (such `string[]`, `array<int, string>`, etc).