### PR TITLE
Add support for more types (union & intersection) and docblock merging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^8.37",
+        "barryvdh/laravel-ide-helper": "^2.10",
+        "lorisleiva/laravel-actions": "^2.2",
         "riimu/kit-pathjoin": "^1.2",
         "spatie/laravel-package-tools": "^1.4.3"
     },

--- a/src/Commands/IdeHelperTestCommand.php
+++ b/src/Commands/IdeHelperTestCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Wulfheart\LaravelActionsIdeHelper\Commands;
+
+use Illuminate\Console\Command;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use ReflectionException;
+use Wulfheart\LaravelActionsIdeHelper\DocBlock\DocBlockFactory;
+
+class IdeHelperTestCommand extends Command
+{
+    public $signature = 'ide-helper:test';
+    protected $hidden = true;
+
+    /**
+     * @throws ReflectionException
+     */
+    public function handle(DocBlockSerializer $docBlockSerializer, DocBlockFactory $docBlockFactory)
+    {
+        $methods = $docBlockFactory->createMethods("App\Models\People\Group");
+        $docBlock = new DocBlock(tags: $methods);
+
+        dump($docBlockSerializer->getDocComment($docBlock));
+    }
+}

--- a/src/DocBlock/DocBlockFactory.php
+++ b/src/DocBlock/DocBlockFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Wulfheart\LaravelActionsIdeHelper\DocBlock;
+
+use phpDocumentor\Reflection\DocBlock\Tags\Method as DocBlockMethod;
+use ReflectionClass;
+use ReflectionException;
+
+class DocBlockFactory
+{
+    private DocBlockFromCommentFactory $fromCommentFactory;
+    private DocBlockFromSignatureFactory $fromSignatureFactory;
+    private DocBlockMerger $merger;
+
+    public function __construct(
+        DocBlockFromCommentFactory $fromCommentFactory,
+        DocBlockFromSignatureFactory $fromSignatureFactory,
+        DocBlockMerger $merger
+    )
+    {
+        $this->fromCommentFactory = $fromCommentFactory;
+        $this->fromSignatureFactory = $fromSignatureFactory;
+        $this->merger = $merger;
+    }
+
+    /**
+     * @param $className
+     * @return DocBlockMethod[]
+     * @throws ReflectionException
+     */
+    public function createMethods($className): array
+    {
+        $reflection = new ReflectionClass($className);
+
+        $signatureMethods = $this->fromSignatureFactory->createMethods($reflection);
+        $commentMethods = $this->fromCommentFactory->createMethods($reflection);
+
+        return $this->merger->mergeMethods($signatureMethods, $commentMethods);
+    }
+}

--- a/src/DocBlock/DocBlockFromCommentFactory.php
+++ b/src/DocBlock/DocBlockFromCommentFactory.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Wulfheart\LaravelActionsIdeHelper\DocBlock;
+
+use ReflectionClass;
+use ReflectionMethod;
+use Barryvdh\LaravelIdeHelper\UsesResolver;
+use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\DocBlock\Tags\Param as DocBlockParam;
+use phpDocumentor\Reflection\DocBlock\Tags\Method as DocBlockMethod;
+use phpDocumentor\Reflection\DocBlock\Tags\Return_ as DocBlockReturn;
+
+class DocBlockFromCommentFactory
+{
+    private DocBlockFactory $factory;
+    private UsesResolver $usesResolver;
+
+    public function __construct(UsesResolver $usesResolver)
+    {
+        $this->factory = DocBlockFactory::createInstance();
+        $this->usesResolver = $usesResolver;
+    }
+
+    /**
+     * @param ReflectionClass $class
+     * @return DocBlockMethod[]
+     */
+    public function createMethods(ReflectionClass $class): array
+    {
+        $context = $this->getContext($class);
+
+        $methodsWithDocs = array_filter($class->getMethods(), fn(ReflectionMethod $m) => $m->getDocComment());
+
+        return array_map(fn($method) => $this->createMethod($method, $context), $methodsWithDocs);
+    }
+
+    private function createMethod(ReflectionMethod $method, Context $context): DocBlockMethod
+    {
+        $isStatic = $method->isStatic();
+
+        $docs = $this->factory->create($method, $context);
+
+        $description = $docs->getDescription();
+
+        /** @var DocBlockReturn[] $returnTags */
+        $returnTags = $docs->getTagsByName("return");
+        $returnType = ($returnTags[0] ?? null)?->getType();
+
+        /** @var DocBlockParam[] $paramTags */
+        $paramTags = $docs->getTagsByName("param");
+        $argTags = array_map([$this, "createArgumentTag"], $paramTags);
+
+        return new DocBlockMethod($method->getName(), $argTags, $returnType, $isStatic, $description);
+    }
+
+    public function createArgumentTag(DocBlockParam $param): array
+    {
+        return [
+            "name" => $param->getVariableName(),
+            "type" => $param->getType()
+        ];
+    }
+
+    private function getContext(ReflectionClass $class): Context
+    {
+        return new Context($class->getName(), $this->getAliases($class));
+    }
+
+    private function getAliases(ReflectionClass $class): array
+    {
+        $className = $class->getName();
+        $traitNames = $this->classUsesDeep($class->getName());
+
+        return collect([$className, ...$traitNames])
+            ->flatMap([$this->usesResolver, "loadFromClass"])
+            ->toArray();
+    }
+
+    private function classUsesDeep($class): array
+    {
+        $traits = [];
+
+        do {
+            $traits = array_merge(class_uses($class), $traits);
+        } while($class = get_parent_class($class));
+
+        foreach ($traits as $trait => $same) {
+            $traits = array_merge(class_uses($trait), $traits);
+        }
+
+        return array_unique($traits);
+    }
+}

--- a/src/DocBlock/DocBlockFromSignatureFactory.php
+++ b/src/DocBlock/DocBlockFromSignatureFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Wulfheart\LaravelActionsIdeHelper\DocBlock;
+
+use ReflectionType;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionParameter;
+use phpDocumentor\Reflection\Type as DocBlockType;
+use phpDocumentor\Reflection\TypeResolver as DocBlockTypeResolver;
+use phpDocumentor\Reflection\DocBlock\Tags\Method as DocBlockMethod;
+
+class DocBlockFromSignatureFactory
+{
+    private DocBlockTypeResolver $docBlockTypeResolver;
+
+    public function __construct(DocBlockTypeResolver $docBlockTypeResolver)
+    {
+        $this->docBlockTypeResolver = $docBlockTypeResolver;
+    }
+
+    /**
+     * @param ReflectionClass $class
+     * @return DocBlockMethod[]
+     */
+    public function createMethods(ReflectionClass $class): array
+    {
+        return array_map([$this, "createMethod"], $class->getMethods());
+    }
+
+    public function createMethod(ReflectionMethod $method): DocBlockMethod
+    {
+        $name = $method->getName();
+        $isStatic = $method->isStatic();
+        $returnType = $method->getReturnType();
+        $parameters = $method->getParameters();
+
+        $docBlockParameters = array_map([$this, "createParameter"], $parameters);
+        $docBlockReturnType = $returnType ? $this->createType($returnType) : null;
+
+        return new DocBlockMethod($name, $docBlockParameters, $docBlockReturnType, $isStatic);
+    }
+
+    public function createType(ReflectionType $type): DocBlockType
+    {
+        return $this->docBlockTypeResolver->resolve((string) $type);
+    }
+
+    public function createParameter(ReflectionParameter $parameter): array
+    {
+        $name = $parameter->getName();
+        $type = $parameter->getType();
+
+        $docBlockType = $type ? $this->createType($type) : null;
+
+        return [
+          "name" => $name,
+          "type" => $docBlockType
+        ];
+    }
+}

--- a/src/DocBlock/DocBlockMerger.php
+++ b/src/DocBlock/DocBlockMerger.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Wulfheart\LaravelActionsIdeHelper\DocBlock;
+
+use Illuminate\Support\Collection;
+use phpDocumentor\Reflection\DocBlock\Description as DocBlockDescription;
+use phpDocumentor\Reflection\DocBlock\Tags\Method as DocBlockMethod;
+use phpDocumentor\Reflection\Types\Void_ as DocBlockVoidType;
+use phpDocumentor\Reflection\Type as DocBlockType;
+
+class DocBlockMerger
+{
+    /**
+     * @param DocBlockMethod[] $methods1
+     * @param DocBlockMethod[] $methods2
+     * @return DocBlockMethod[]
+     */
+    public function mergeMethods(array $methods1, array $methods2): array
+    {
+        $collection1 = $this->collectByMethodName($methods1);
+        $collection2 = $this->collectByMethodName($methods2);
+
+        $uniqueMethods = $collection1->diffKeys($collection2);
+        $duplicates = $collection1->intersectByKeys($collection2);
+
+        return $duplicates
+            ->map(function(DocBlockMethod $method1) use ($collection2) {
+                $name = $method1->getMethodName();
+                $isStatic = $method1->isStatic();
+
+                /** @var DocBlockMethod $method2 */
+                $method2 = $collection2->get($name);
+
+                return new DocBlockMethod(
+                    $name,
+                    $this->mergeArguments($method1->getArguments(), $method2->getArguments()),
+                    $this->mergeReturnTypes($method1->getReturnType(), $method2->getReturnType()),
+                    $isStatic,
+                    $this->mergeDescription($method1->getDescription(), $method2->getDescription())
+                );
+            })
+            ->merge($uniqueMethods)
+            ->toArray();
+    }
+
+    /**
+     * @param DocBlockMethod[] $methods
+     * @return Collection
+     */
+    private function collectByMethodName(array $methods): Collection
+    {
+        return collect($methods)->keyBy(fn(DocBlockMethod $m) => $m->getMethodName());
+    }
+
+    private function mergeArguments(array $method1, array $method2): array
+    {
+        $byName1 = collect($method1)->keyBy("name");
+        $byName2 = collect($method2)->keyBy("name");
+
+        return $byName1->merge($byName2)->values()->toArray();
+    }
+
+    private function mergeReturnTypes(DocBlockType $return1, DocBlockType $return2): DocBlockType
+    {
+        if($return2 instanceof DocBlockVoidType) {
+            return $return1;
+        }
+
+        return $return2;
+    }
+
+    private function mergeDescription(?DocBlockDescription $description1, ?DocBlockDescription $description2): ?DocBlockDescription
+    {
+        if(is_null($description2)) {
+            return $description1;
+        }
+
+        return $description2;
+    }
+}

--- a/src/LaravelActionsIdeHelperServiceProvider.php
+++ b/src/LaravelActionsIdeHelperServiceProvider.php
@@ -4,6 +4,7 @@ namespace Wulfheart\LaravelActionsIdeHelper;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Wulfheart\LaravelActionsIdeHelper\Commands\IdeHelperTestCommand;
 use Wulfheart\LaravelActionsIdeHelper\Commands\LaravelActionsIdeHelperCommand;
 
 class LaravelActionsIdeHelperServiceProvider extends PackageServiceProvider
@@ -20,6 +21,7 @@ class LaravelActionsIdeHelperServiceProvider extends PackageServiceProvider
             // ->hasConfigFile()
             // ->hasViews()
             // ->hasMigration('create_laravel-actions-ide-helper_table')
-            ->hasCommand(LaravelActionsIdeHelperCommand::class);
+            ->hasCommand(LaravelActionsIdeHelperCommand::class)
+            ->hasCommands(IdeHelperTestCommand::class);
     }
 }


### PR DESCRIPTION
I rewrote the docblock logic to better support testing, more types (like union and intersection types) and merging signature types (all the build in stuff) with docblock types.

The logic for merging docblocks with signature works as follows
* if there is no docblock, use signature types
* if there is a docblock, prefer docblock types over signature types (because docblocks support more types like string[])

The factories return an array of Methods (phpDocumentor\Reflection\DocBlock package) for the provided class. In the future these could be used for actions.

This code currently isn't used anywhere, but you can test it with the test command. I will add tests soon.