### PR TITLE
fix incompatible types with phpdocumentor/reflection-docblock (5.4.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
             "Wulfheart\\LaravelActionsIdeHelper\\Tests\\": "tests"
         }
     },
-    "scripts": [],
+    "scripts": {},
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
             "Wulfheart\\LaravelActionsIdeHelper\\Tests\\": "tests"
         }
     },
-    "scripts": {},
+    "scripts": [],
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/src/Service/Generator/DocBlock/Custom/Method.php
+++ b/src/Service/Generator/DocBlock/Custom/Method.php
@@ -9,7 +9,7 @@ use phpDocumentor\Reflection\Type;
 
 class Method extends BaseTag
 {
-    protected $name = 'method';
+    protected string $name = 'method';
 
     /**
      * @param  string  $methodName
@@ -23,7 +23,7 @@ class Method extends BaseTag
         protected array $arguments = [],
         protected ?Type $returnType = null,
         protected bool $static = false,
-        protected $description = null
+        protected ?Description $description = null
     ) {
 
     }


### PR DESCRIPTION
Method class wasn't fully compatible with newer versions of phpdocumentor. 

Will see errors like this when trying to generate actions: 

```Symfony\Component\ErrorHandler\Error\FatalError 

  Type of Wulfheart\LaravelActionsIdeHelper\Service\Generator\DocBlock\Custom\Method::$name must be string (as in class phpDocumentor\Reflection\DocBlock\Tags\BaseTag)