### PR TITLE
Bump lorisleiva/lody

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.1|^8.2",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "lorisleiva/laravel-actions": "^2.3",
-        "lorisleiva/lody": "^0.5.0",
+        "lorisleiva/lody": "^0.5.0|^0.6.0",
         "phpdocumentor/reflection": "^5.1|^6.0",
         "riimu/kit-pathjoin": "^1.2",
         "spatie/laravel-package-tools": "^1.14"


### PR DESCRIPTION
On a fresh Laravel 12 install:

`composer require --dev wulfheart/laravel-actions-ide-helper:dev-main -W  lorisleiva/lody:0.6.0`

```./composer.json has been updated
Running composer update wulfheart/laravel-actions-ide-helper lorisleiva/lody --with-all-dependencies
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires wulfheart/laravel-actions-ide-helper dev-main -> satisfiable by wulfheart/laravel-actions-ide-helper[dev-main].
    - wulfheart/laravel-actions-ide-helper dev-main requires lorisleiva/lody ^0.5.0 -> found lorisleiva/lody[v0.5.0] but it conflicts with your root composer.json require (0.6.0).```