### PR TITLE
Laravel 13.x Compatibility - with lody

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.1|^8.2",
         "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "lorisleiva/laravel-actions": "^2.3",
-        "lorisleiva/lody": "^0.5.0|^0.6.0",
+        "lorisleiva/lody": "^0.5|^0.6|^0.7",
         "phpdocumentor/reflection": "^5.1|^6.0",
         "riimu/kit-pathjoin": "^1.2",
         "spatie/laravel-package-tools": "^1.14"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1|^8.2",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "lorisleiva/laravel-actions": "^2.3",
         "lorisleiva/lody": "^0.5.0|^0.6.0",
         "phpdocumentor/reflection": "^5.1|^6.0",
@@ -27,9 +27,9 @@
     "require-dev": {
         "brianium/paratest": "^6.8|^7.4",
         "nunomaduro/collision": "^6.1|^8.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "^1.22|^2.34|^3.7",
-        "phpunit/phpunit": "^9.5.10|^10.5|^11.5.3",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^1.22|^2.34|^3.7|^4.4",
+        "phpunit/phpunit": "^9.5.10|^10.5|^11.5.3|^12.5.12",
         "spatie/invade": "^1.1|^2.0",
         "spatie/laravel-ray": "^1.32",
         "spatie/pest-plugin-snapshots": "^1.1|^2.1",


### PR DESCRIPTION
This extends #31 by also bumping `lorisleiva/lody`, which is required for full compatibility with Laravel 13.

Merging mine would also mark #31 as merged.